### PR TITLE
Change second arg for GetUnusedRB function

### DIFF
--- a/K8sPurger.py
+++ b/K8sPurger.py
@@ -282,10 +282,10 @@ def DefinedRoleBinding(RbacAuthorizationV1Api):
     return RoleBinding
 
 
-def GetUnusedRB(SA, UsedSA):
+def GetUnusedRB(SA, ExtraSA):
     ExtraRoleBinding = []
     for i, j in RoleBinding.items():
-        if j not in SA or j in UsedSA:
+        if j not in SA or j in ExtraSA:
             ExtraRoleBinding.append([i, j[1]])
     RoleBinding.clear()
     return ExtraRoleBinding


### PR DESCRIPTION
Compared with GetUnusedIng function and the usage in the line 63, the "ExtraSA" is better than "UsedSA" in the GetUnusedRB function.